### PR TITLE
[JENKINS-51844] Fix master-agent startup ordering

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -4,6 +4,7 @@ RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true 
     add-apt-repository -y ppa:webupd8team/java && \
     apt-get update && \
     apt-get install -y oracle-java8-installer && \
+    apt-get install -y iputils-ping && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/oracle-jdk8-installer
 ADD target/remoting-kafka-agent-1.0-SNAPSHOT-jar-with-dependencies.jar remoting-kafka-agent.jar

--- a/agent/src/main/java/io/jenkins/plugins/remotingkafka/Engine.java
+++ b/agent/src/main/java/io/jenkins/plugins/remotingkafka/Engine.java
@@ -189,6 +189,7 @@ public class Engine extends Thread {
         consumerProps.put(KafkaConfigs.ENABLE_AUTO_COMMIT, "false");
         consumerProps.put(KafkaConfigs.KEY_DESERIALIZER, StringDeserializer.class);
         consumerProps.put(KafkaConfigs.VALUE_DESERIALIZER, ByteArrayDeserializer.class);
+        consumerProps.put(KafkaConfigs.AUTO_OFFSET_RESET, "earliest");
         KafkaConsumer<String, byte[]> consumer = new KafkaConsumer<>(consumerProps);
 
         return new KafkaClassicCommandTransport(cap, producerTopic, producerKey, consumerTopics, consumerKey, 0, producer, consumer);

--- a/kafka-client-lib/src/main/java/io/jenkins/plugins/remotingkafka/KafkaConfigs.java
+++ b/kafka-client-lib/src/main/java/io/jenkins/plugins/remotingkafka/KafkaConfigs.java
@@ -16,4 +16,5 @@ public class KafkaConfigs {
     public static final String ENABLE_AUTO_COMMIT = "enable.auto.commit";
     public static final String KEY_DESERIALIZER = "key.deserializer";
     public static final String VALUE_DESERIALIZER = "value.deserializer";
+    public static final String AUTO_OFFSET_RESET = "auto.offset.reset";
 }

--- a/plugin/src/main/java/io/jenkins/plugins/remotingkafka/KafkaComputerLauncher.java
+++ b/plugin/src/main/java/io/jenkins/plugins/remotingkafka/KafkaComputerLauncher.java
@@ -129,6 +129,7 @@ public class KafkaComputerLauncher extends ComputerLauncher {
         consumerProps.put(KafkaConfigs.GROUP_ID, "master-" + nodeName);
         consumerProps.put(KafkaConfigs.KEY_DESERIALIZER, StringDeserializer.class);
         consumerProps.put(KafkaConfigs.VALUE_DESERIALIZER, ByteArrayDeserializer.class);
+        consumerProps.put(KafkaConfigs.AUTO_OFFSET_RESET, "earliest");
         KafkaConsumer<String, byte[]> consumer = new KafkaConsumer<>(consumerProps);
         return new KafkaClassicCommandTransport(cap, producerTopic, producerKey, consumerTopics, consumerKey, 0, producer, consumer);
     }


### PR DESCRIPTION
JIRA task: [JENKINS-51844](https://issues.jenkins-ci.org/browse/JENKINS-51844)

**Problem**: If we start master first then agent, there will be no connection setup.

**Root cause**: According to https://kafka.apache.org/documentation/#newconsumerconfigs, `auto.offset.reset` is set default to `latest`, is the latest offset position in the partition of a topic. If we produce a message first in offset 0, the default consumer position is offset 1. This leads to mismatch offset in consumer-producer, therefore the communication channel is not established.

**Proposed change**: Change the consumer config of `auto.offset.reset` to `earliest` which indicates the earliest offset position is not consumed in the partition. This helps to synchronize the message between 2 sides and we can make connection setup between master-agent be flexible.

@oleg-nenashev @Supun94 @dwnusbaum @jeffret-b 