### PR TITLE
Rename groupId to avoid naming redundancy

### DIFF
--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -4,12 +4,13 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>io.jenkins.plugins.remoting-kafka</groupId>
+        <groupId>io.jenkins.plugins</groupId>
         <artifactId>remoting-kafka-plugin</artifactId>
         <version>1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <groupId>io.jenkins.plugins</groupId>
     <artifactId>remoting-kafka-agent</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
@@ -54,7 +55,7 @@
             <version>2.33</version>
         </dependency>
         <dependency>
-            <groupId>io.jenkins.plugins.remoting-kafka</groupId>
+            <groupId>io.jenkins.plugins</groupId>
             <artifactId>kafka-client-lib</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>

--- a/kafka-client-lib/pom.xml
+++ b/kafka-client-lib/pom.xml
@@ -3,13 +3,14 @@
          xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <groupId>io.jenkins.plugins.remoting-kafka</groupId>
+        <groupId>io.jenkins.plugins</groupId>
         <artifactId>remoting-kafka-plugin</artifactId>
         <version>1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <groupId>io.jenkins.plugins</groupId>
     <artifactId>kafka-client-lib</artifactId>
     <name>Kafka Client Module</name>
     <version>1.0-SNAPSHOT</version>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -9,7 +9,7 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <groupId>io.jenkins.plugins.remoting-kafka</groupId>
+    <groupId>io.jenkins.plugins</groupId>
     <artifactId>remoting-kafka</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
@@ -21,7 +21,7 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>io.jenkins.plugins.remoting-kafka</groupId>
+            <groupId>io.jenkins.plugins</groupId>
             <artifactId>kafka-client-lib</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
         <version>1.46</version>
     </parent>
 
-    <groupId>io.jenkins.plugins.remoting-kafka</groupId>
+    <groupId>io.jenkins.plugins</groupId>
     <artifactId>remoting-kafka-plugin</artifactId>
     <name>Remoting Kafka Plugin</name>
     <description>Allows users to start agent using Kafka</description>


### PR DESCRIPTION
This PR renames `groupId` in pom files to avoid naming redundancy.

@oleg-nenashev @Supun94 