### PR TITLE
[JENKINS-52343] Fix exception of closeRead() method in KafkaClassicCommandTransport

### DIFF
--- a/kafka-client-lib/src/main/java/io/jenkins/plugins/remotingkafka/commandtransport/KafkaClassicCommandTransport.java
+++ b/kafka-client-lib/src/main/java/io/jenkins/plugins/remotingkafka/commandtransport/KafkaClassicCommandTransport.java
@@ -35,6 +35,7 @@ public class KafkaClassicCommandTransport extends SynchronousCommandTransport {
     private final long pollTimeout;
     private final int producerPartition;
     private final int consumerPartition;
+    private boolean isReadClosed;
 
     private Queue<Command> commandQueue;
 
@@ -50,6 +51,7 @@ public class KafkaClassicCommandTransport extends SynchronousCommandTransport {
         this.producerPartition = settings.getProducerPartition();
         this.consumerPartition = settings.getConsumerPartition();
         this.commandQueue = new ConcurrentLinkedQueue<>();
+        this.isReadClosed = false;
     }
 
     @Override
@@ -71,8 +73,11 @@ public class KafkaClassicCommandTransport extends SynchronousCommandTransport {
 
     @Override
     public final void closeRead() throws IOException {
-        consumer.commitSync();
-        KafkaUtils.unassignConsumer(consumer);
+        if (!isReadClosed) {
+            consumer.commitSync();
+            KafkaUtils.unassignConsumer(consumer);
+            isReadClosed = true;
+        }
     }
 
     @Override


### PR DESCRIPTION
JIRA task: [JENKINS-52343](https://issues.jenkins-ci.org/browse/JENKINS-52343)

Reason: Exception is thrown because the close read command is sent in both direction over the communication channel, which caused the consumer to be closed twice.

Solution: Add a global variable `isReadClosed` to check the state of the channel.

@oleg-nenashev @Supun94 @dwnusbaum @jeffret-b 