### PR TITLE
[JENKINS-52079] Tear down connection when master or agent stops

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
             CASC_JENKINS_CONFIG: /var/jenkins_home/casc_configs/jenkins.yaml
 
     kafka:
-        image: wurstmeister/kafka:latest
+        image: wurstmeister/kafka:2.11-1.1.0
         ports:
             - "9092:9092"
             - "9999:9999"

--- a/plugin/src/main/java/io/jenkins/plugins/remotingkafka/KafkaComputerLauncher.java
+++ b/plugin/src/main/java/io/jenkins/plugins/remotingkafka/KafkaComputerLauncher.java
@@ -75,13 +75,13 @@ public class KafkaComputerLauncher extends ComputerLauncher {
             @Override
             public Boolean call() throws Exception {
                 Boolean rval = Boolean.FALSE;
+                String topic = KafkaConfigs.getConnectionTopic(computer.getName(), retrieveJenkinsURL());
+                KafkaUtils.createTopic(topic, GlobalKafkaConfiguration.get().getZookeeperURL(),
+                        4, 1);
+                if (!isValidAgent(computer.getName(), listener)) {
+                    return Boolean.FALSE;
+                }
                 try {
-                    String topic = KafkaConfigs.getConnectionTopic(computer.getName(), retrieveJenkinsURL());
-                    KafkaUtils.createTopic(topic, GlobalKafkaConfiguration.get().getZookeeperURL(),
-                            4, 1);
-                    if (!isValidAgent(computer.getName(), listener)) {
-                        return false;
-                    }
                     ChannelBuilder cb = new ChannelBuilder(computer.getName(), computer.threadPoolForRemoting)
                             .withHeaderStream(listener.getLogger());
                     CommandTransport ct = makeTransport(computer);

--- a/plugin/src/main/java/io/jenkins/plugins/remotingkafka/KafkaSecretManager.java
+++ b/plugin/src/main/java/io/jenkins/plugins/remotingkafka/KafkaSecretManager.java
@@ -37,9 +37,9 @@ public final class KafkaSecretManager {
     /**
      * Timeout in milliseconds.
      */
-    private int timeout;
+    private long timeout;
 
-    public KafkaSecretManager(String agentName, KafkaTransportBuilder settings, int timeout, TaskListener listener) {
+    public KafkaSecretManager(String agentName, KafkaTransportBuilder settings, long timeout, TaskListener listener) {
         this.agentName = agentName;
         this.producer = settings.getProducer();
         this.consumer = settings.getConsumer();

--- a/plugin/src/main/resources/io/jenkins/plugins/remotingkafka/Messages.properties
+++ b/plugin/src/main/resources/io/jenkins/plugins/remotingkafka/Messages.properties
@@ -7,3 +7,4 @@ KafkaComputerLauncher.NonnullExecutorService=Launcher Executor Service should be
 GlobalKafkaConfiguration.KafkaConnectionURLWarning=Please specify a Kafka connection URL
 GlobalKafkaConfiguration.KafkaSecurityWarning=Required for Kafka security reasons
 GlobalKafkaConfiguration.ZookeeperURLWarning=Please specify a Zookeeper URL
+KafkaComputerLauncher.UnexpectedError=Unexpected error in launching a slave. This is probably a bug in Jenkins.


### PR DESCRIPTION
JIRA task: [JENKINS-52079](https://issues.jenkins-ci.org/browse/JENKINS-52079)

- When agent stops, master will try to re-connect and detect disconnection.
- When master stops, agent cannot execute build anymore unless it is connected again to master.

This is done by handling exceptions and return a proper boolean value in `call()` method. The implementation is similar to `SSHLauncher` https://github.com/jenkinsci/ssh-slaves-plugin/blob/master/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java#L814

@oleg-nenashev @Supun94 @dwnusbaum @jeffret-b 