### PR TITLE
[JENKINS-52987] Update demo instruction to use the plugin without Kafka-enabled SSL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,9 @@ run:
 	echo "Waiting 60s for jenkins to be ready..."
 	sleep 60
 	docker-compose up -d agent
+
+run-no-auth:
+	docker-compose up -d zoo2 kafka-no-auth jenkins-no-auth
+	echo "Waiting 60s for jenkins to be ready..."
+	sleep 60
+	docker-compose up -d agent-no-auth

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ See [DOCUMENTATION](docs/DOCUMENTATION.md)
 
 3. Build the demo: `make all`.
 
-4. Run the demo: `make run`.
+4. Run the demo: `make run` (without security feature `make run-no-auth`).
 
 5. Features in the demo:
 

--- a/demo/jenkins_no_auth.yaml
+++ b/demo/jenkins_no_auth.yaml
@@ -1,0 +1,58 @@
+jenkins:
+  systemMessage: "Jenkins configured automatically by Jenkins Configuration as Code Plugin
+                  for the demo of Remoting Kafka Plugin
+                  https://github.com/jenkinsci/remoting-kafka-plugin.\n\n"
+  numExecutors: 1
+  scmCheckoutRetryCount: 2
+  mode: NORMAL
+  securityRealm:
+    local:
+      users:
+        - id: "admin"
+          password: "admin"
+
+  nodes:
+    - permanent:
+        name: "test"
+        remoteFS: "/home/jenkins"
+        launcher:
+          kafka:
+            enableSSL: "false"
+
+unclassified:
+  location:
+    url: http://localhost:8080/
+  
+  kafka:
+    brokerURL: 172.17.0.1:9093
+    zookeeperURL: 172.17.0.1:2182
+    enableSSL: false
+
+jobs:
+  - >
+    pipelineJob('demo_hello') {
+        definition {
+            cps {
+                sandbox()
+                script("""
+                    node('test') {
+                      sh "echo Hello World"
+                    }
+                """.stripIndent())
+            }
+        }
+    }
+
+  - >
+    pipelineJob('demo_ping') {
+        definition {
+            cps {
+                sandbox()
+                script("""
+                    node('test') {
+                      sh "ping -c 20 google.com"
+                    }
+                """.stripIndent())
+            }
+        }
+    }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,6 +89,22 @@ services:
             APPLICATION_SECRET: "random-secret"
         command: -Dpidfile.path=/dev/null
 
+    jenkins-no-auth:
+        build:
+            context: .
+            dockerfile: jenkins/Dockerfile
+        ports:
+            - "8080:8080"
+            - "36088:36088"
+        links:
+            - zoo2
+            - kafka-no-auth
+        volumes:
+            - './demo/jenkins_no_auth.yaml:/var/jenkins_home/casc_configs/jenkins.yaml'
+            - './demo/init.groovy:/var/jenkins_home/init.groovy'
+        environment:
+            CASC_JENKINS_CONFIG: /var/jenkins_home/casc_configs/jenkins.yaml
+
     zoo2:
         image: wurstmeister/zookeeper:latest
         ports:
@@ -106,3 +122,15 @@ services:
             KAFKA_ZOOKEEPER_CONNECT: zoo2:2181
         volumes:
             - /var/run/docker.sock:/var/run/docker.sock
+
+    agent-no-auth:
+        image: jenkins/remoting-kafka-agent:latest
+        command: >
+            -name test -master http://localhost:8080/
+            -secret 43b0cef99265f9e34c10ea9d3501926d27b39f57c6d674561d8ba236e7a819fb
+            -kafkaURL 172.17.0.1:9093
+            -noauth
+        depends_on:
+            - zoo2
+            - kafka-no-auth
+            - jenkins-no-auth


### PR DESCRIPTION
JIRA task: [JENKINS-52987](https://issues.jenkins-ci.org/browse/JENKINS-52987)

@oleg-nenashev @Supun94 @dwnusbaum @jeffret-b 