### PR TITLE
[Fix] Downgrade remoting and update jenkins core version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all: clean build
 clean:
 	docker-compose down
 build:
-	mvn clean package -DskipTests
+	mvn clean install -DskipTests
 	./ssl_setup.sh
 	docker-compose build
 	docker-compose pull

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.129
+FROM jenkins/jenkins:2.132
 ADD plugin/target/remoting-kafka.hpi /usr/share/jenkins/ref/plugins/remoting-kafka.jpi
 USER root
 RUN install-plugins.sh credentials:2.1.17 configuration-as-code:0.10-alpha workflow-aggregator:2.5 job-dsl:1.70

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.132
+FROM jenkins/jenkins:2.138.1
 ADD plugin/target/remoting-kafka.hpi /usr/share/jenkins/ref/plugins/remoting-kafka.jpi
 USER root
 RUN install-plugins.sh credentials:2.1.17 configuration-as-code:0.10-alpha workflow-aggregator:2.5 job-dsl:1.70

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -14,7 +14,7 @@
     <packaging>hpi</packaging>
     <name>Remoting Kafka Plugin</name>
     <properties>
-        <jenkins.version>2.129</jenkins.version>
+        <jenkins.version>2.132</jenkins.version>
         <java.level>8</java.level>
         <useBeta>true</useBeta>
     </properties>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -14,7 +14,7 @@
     <packaging>hpi</packaging>
     <name>Remoting Kafka Plugin</name>
     <properties>
-        <jenkins.version>2.132</jenkins.version>
+        <jenkins.version>2.138.1</jenkins.version>
         <java.level>8</java.level>
         <useBeta>true</useBeta>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <remoting.version>3.23</remoting.version>
-        <jenkins.version>2.132</jenkins.version>
+        <jenkins.version>2.138.1</jenkins.version>
         <java.level>8</java.level>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
     <packaging>pom</packaging>
 
     <properties>
-        <remoting.version>3.26</remoting.version>
-        <jenkins.version>2.129</jenkins.version>
+        <remoting.version>3.23</remoting.version>
+        <jenkins.version>2.132</jenkins.version>
         <java.level>8</java.level>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <remoting.version>3.23</remoting.version>
+        <remoting.version>3.25</remoting.version>
         <jenkins.version>2.138.1</jenkins.version>
         <java.level>8</java.level>
     </properties>


### PR DESCRIPTION
**Upgrade** core to 2.132 because: There is a hidden dependencies with [folders plugin](https://github.com/jenkinsci/cloudbees-folder-plugin) which 2.129 doesn't support anymore, the nearest version I can found workable is 2.132.

**Downgrade** remoting from 3.26 - 3.23: 3.26 caused cancellation exception when starting Kafka agent, which made the demo of the plugin failed (my mistake did not test when making a PR last time).
The temporary solution is to patch like this so that we have a workable demo of the plugin, then I will spin a 1.1.1 release for this. Other issues need to be investigated later.

@oleg-nenashev 