### PR TITLE
Fix docker build for remoting kafka agent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY plugin/ /jenkins/src/plugin/
 COPY pom.xml /jenkins/src/pom.xml
 
 WORKDIR /jenkins/src/
-RUN mvn clean install -DskipTests --batch-mode
+RUN mvn clean -Dtest=\!KafkaComputerLauncherTest -DfailIfNoTests=false install --batch-mode
 
 # copy agent
 FROM ubuntu

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY plugin/ /jenkins/src/plugin/
 COPY pom.xml /jenkins/src/pom.xml
 
 WORKDIR /jenkins/src/
-RUN mvn clean install --batch-mode
+RUN mvn clean install -DskipTests --batch-mode
 
 # copy agent
 FROM ubuntu

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '2'
 services:
     agent:
+        # build: . # For local testing only.
         image: jenkins/remoting-kafka-agent:latest
         volumes:
             - './certs/docker.kafka.server.keystore.jks:/kafka.keystore.jks:ro'


### PR DESCRIPTION
Solution: Skip tests in docker build.

@oleg-nenashev 