### PR TITLE
Change to use Open JDK for agent docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,16 +8,27 @@ COPY pom.xml /jenkins/src/pom.xml
 WORKDIR /jenkins/src/
 RUN mvn clean -Dtest=\!KafkaComputerLauncherTest -DfailIfNoTests=false install --batch-mode
 
-# copy agent
-FROM ubuntu
-RUN apt-get update && apt-get install -y software-properties-common
-RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | debconf-set-selections && \
-    add-apt-repository -y ppa:webupd8team/java && \
-    apt-get update && \
-    apt-get install -y oracle-java8-installer && \
-    apt-get install -y iputils-ping && \
-    rm -rf /var/lib/apt/lists/* && \
-    rm -rf /var/cache/oracle-jdk8-installer
+# Install OpenJDK-8
+FROM ubuntu:18.04
+RUN apt-get update && \
+    apt-get install -y openjdk-8-jdk && \
+    apt-get install -y ant && \
+    apt-get clean;
+
+# Fix certificate issues
+RUN apt-get update && \
+    apt-get install ca-certificates-java && \
+    apt-get clean && \
+    update-ca-certificates -f;
+
+# Setup JAVA_HOME -- useful for docker commandline
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/
+RUN export JAVA_HOME
+
+# Install ping utils
+RUN apt-get install -y iputils-ping
+
+# Copy agent
 COPY --from=builder /jenkins/src/agent/target/remoting-kafka-agent.jar remoting-kafka-agent.jar
 ENTRYPOINT ["java", "-jar", "remoting-kafka-agent.jar"]
 CMD ["-help"]


### PR DESCRIPTION
Docker build is still failing due to 404 not found when installing Java in Docker image https://hub.docker.com/r/jenkins/remoting-kafka-agent/builds/bm9nomanvgypolhsxamxx95/, this PR is to change to use OpenJDK.

@oleg-nenashev 