### PR TITLE
Update README.md on setting DOCKERHOST

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,11 @@ See the [CHANGELOG](CHANGELOG.md).
 
 1. Requirements: docker, docker-compose installed.
 
-2. Run `export DOCKERHOST=$(ifconfig docker0 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}')`
+2. Set environment variable `DOCKERHOST`
+
+- Windows: `set DOCKERHOST=host.docker.internal`
+- macOS: `export DOCKERHOST=host.docker.internal`
+- Linux: `export DOCKERHOST=$(ifconfig docker0 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}')`
 
 3. Build the demo: `make all`.
 


### PR DESCRIPTION
I ran into this problem when trying to run the demo on macOS. 
Apparently, Docker's networking is configured differently on macOS and Windows so we can't use `ifconfig docker0` to find Docker's host address. However, from Docker 18.03 onwards we can use a special DNS name `host.docker.internal`, which resolves to the internal IP address used by the host. 

More information:
- Windows: https://docs.docker.com/docker-for-windows/networking/#known-limitations-use-cases-and-workarounds
- macOS: https://docs.docker.com/docker-for-mac/networking/#known-limitations-use-cases-and-workarounds