### PR TITLE
Update Long's developer ID in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
             <email>phamvutuan10@gmail.com</email>
         </developer>
         <developer>
-            <id>longngn</id>
+            <id>vulong237</id>
             <name>Nguyen Le Vu Long</name>
             <email>vulongvn98@gmail.com</email>
         </developer>


### PR DESCRIPTION
Turns out the developer ID in `pom.xml` has to be my jenkins-ci.org ID, not my GitHub ID