### PR TITLE
[JENKINS-57668] Implement Cloud on Kubernetes

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/remotingkafka/GlobalKafkaConfiguration.java
+++ b/plugin/src/main/java/io/jenkins/plugins/remotingkafka/GlobalKafkaConfiguration.java
@@ -153,6 +153,10 @@ public class GlobalKafkaConfiguration extends GlobalConfiguration {
         this.kubernetesApiPort = kubernetesApiPort;
     }
 
+    public String getKubernetesUrl() {
+        return getURL(getKubernetesIp(), Integer.parseInt(getKubernetesApiPort()));
+    }
+
     public String getKubernetesCertificate() {
         return kubernetesCertificate;
     }
@@ -379,7 +383,7 @@ public class GlobalKafkaConfiguration extends GlobalConfiguration {
                     testConnection(serverIp, kafkaPort);
                     break;
                 } catch (IOException e) {
-                    LOGGER.info(String.format("Waiting for Kafka connection at %s:%s", serverIp, kafkaPort));
+                    LOGGER.fine(String.format("Waiting for Kafka connection at %s:%s", serverIp, kafkaPort));
                 }
                 TimeUnit.SECONDS.sleep(1);
             }

--- a/plugin/src/main/java/io/jenkins/plugins/remotingkafka/KafkaCloudComputer.java
+++ b/plugin/src/main/java/io/jenkins/plugins/remotingkafka/KafkaCloudComputer.java
@@ -1,0 +1,14 @@
+package io.jenkins.plugins.remotingkafka;
+
+import hudson.slaves.AbstractCloudComputer;
+
+import java.util.logging.Logger;
+
+public class KafkaCloudComputer extends AbstractCloudComputer<KafkaCloudSlave> {
+    private static final Logger LOGGER = Logger.getLogger(KafkaCloudComputer.class.getName());
+
+    public KafkaCloudComputer(KafkaCloudSlave slave) {
+        super(slave);
+    }
+
+}

--- a/plugin/src/main/java/io/jenkins/plugins/remotingkafka/KafkaCloudSlave.java
+++ b/plugin/src/main/java/io/jenkins/plugins/remotingkafka/KafkaCloudSlave.java
@@ -1,0 +1,116 @@
+package io.jenkins.plugins.remotingkafka;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import hudson.model.TaskListener;
+import hudson.slaves.*;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import jenkins.model.Jenkins;
+import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang.StringUtils;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.logging.Logger;
+
+public class KafkaCloudSlave extends AbstractCloudSlave {
+    private static final Logger LOGGER = Logger.getLogger(KafkaCloudSlave.class.getName());
+    private static final String DEFAULT_AGENT_PREFIX = "remoting-kafka-agent";
+
+    private String cloudName;
+
+    public String getName() {
+        return name;
+    }
+
+    public String getCloudName() {
+        return cloudName;
+    }
+
+    public void setCloudName(String cloudName) {
+        this.cloudName = cloudName;
+    }
+
+    @Nonnull
+    public KafkaKubernetesCloud getCloud() {
+        return getCloud(cloudName);
+    }
+
+    private static KafkaKubernetesCloud getCloud(String cloudName) {
+        Cloud cloud = Jenkins.get().getCloud(cloudName);
+        if (cloud instanceof KafkaKubernetesCloud) {
+            return (KafkaKubernetesCloud) cloud;
+        } else {
+            throw new IllegalStateException(KafkaCloudSlave.class.getName() + " can be launched only by instances of " + KafkaKubernetesCloud.class.getName() + ". Cloud is " + cloud.getClass().getName());
+        }
+    }
+
+    public String getNamespace() {
+        return getCloud().getNamespace();
+    }
+
+    public KafkaCloudSlave(KafkaKubernetesCloud cloud) throws Descriptor.FormException, IOException {
+        super(getSlaveName(cloud.name),
+                "",
+                // TODO: Remote FS field in Cloud config
+                "/workingDir",
+                1,
+                // TODO: Node usage mode field
+                Mode.NORMAL,
+                cloud.getLabel(),
+                // TODO: SSL field
+                new KafkaComputerLauncher(),
+                // TODO: Retention strat
+                CloudSlaveRetentionStrategy.INSTANCE,
+                // TODO: Node properties field
+                new ArrayList<>());
+
+        this.cloudName = cloud.name;
+    }
+
+    private static String getSlaveName(String baseName) {
+        String randString = RandomStringUtils.random(5, "bcdfghjklmnpqrstvwxz0123456789");
+        String name = baseName;
+        if (StringUtils.isEmpty(name)) {
+            return String.format("%s-%s", DEFAULT_AGENT_PREFIX, randString);
+        }
+        // Because the name is also used in Kubernetes, it should conform to domain name standard
+        // No spaces, lower-cased
+        name = name.replaceAll("[ _]", "-").toLowerCase();
+        // Keep it under 63 chars (62 is used to account for the '-')
+        name = name.substring(0, Math.min(name.length(), 62 - randString.length()));
+        return String.format("%s-%s", name, randString);
+    }
+
+    @Override
+    public AbstractCloudComputer createComputer() {
+        return new KafkaCloudComputer(this);
+    }
+
+    @Override
+    protected void _terminate(TaskListener listener) throws IOException, InterruptedException {
+        LOGGER.info("Terminating Kubernetes instance for agent " + name);
+        KafkaKubernetesCloud cloud = getCloud();
+        KubernetesClient client = cloud.connect();
+        Boolean deleted = client.pods().inNamespace(getNamespace()).withName(name).delete();
+        if (!deleted) {
+            LOGGER.warning(String.format("Failed to delete pod for agent %s/%s: not found", getNamespace(), name));
+        }
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends SlaveDescriptor {
+
+        @Override
+        public String getDisplayName() {
+            return "Kafka Cloud Agent";
+        }
+
+        @Override
+        public boolean isInstantiable() {
+            return false;
+        }
+
+    }
+}

--- a/plugin/src/main/java/io/jenkins/plugins/remotingkafka/KafkaCloudSlave.java
+++ b/plugin/src/main/java/io/jenkins/plugins/remotingkafka/KafkaCloudSlave.java
@@ -52,19 +52,17 @@ public class KafkaCloudSlave extends AbstractCloudSlave {
 
     public KafkaCloudSlave(KafkaKubernetesCloud cloud) throws Descriptor.FormException, IOException {
         super(getSlaveName(cloud.name),
-                "",
-                // TODO: Remote FS field in Cloud config
-                "/workingDir",
-                1,
-                // TODO: Node usage mode field
-                Mode.NORMAL,
+                cloud.getDescription(),
+                cloud.getWorkingDir(),
+                KafkaKubernetesCloud.AGENT_NUM_EXECUTORS,
+                cloud.getNodeUsageMode(),
                 cloud.getLabel(),
-                // TODO: SSL field
-                new KafkaComputerLauncher(),
+                cloud.isEnableSSL() ?
+                        new KafkaComputerLauncher(cloud.getKafkaUsername(), cloud.getSslTruststoreLocation(), cloud.getSslKeystoreLocation())
+                        : new KafkaComputerLauncher(),
                 // TODO: Retention strat
                 CloudSlaveRetentionStrategy.INSTANCE,
-                // TODO: Node properties field
-                new ArrayList<>());
+                cloud.getNodeProperties());
 
         this.cloudName = cloud.name;
     }

--- a/plugin/src/main/java/io/jenkins/plugins/remotingkafka/KafkaCloudSlave.java
+++ b/plugin/src/main/java/io/jenkins/plugins/remotingkafka/KafkaCloudSlave.java
@@ -73,7 +73,7 @@ public class KafkaCloudSlave extends AbstractCloudSlave {
         this.cloudName = cloud.name;
     }
 
-    private static String getSlaveName(String baseNameArg) {
+    public static String getSlaveName(String baseNameArg) {
         String baseName = StringUtils.defaultIfBlank(baseNameArg, DEFAULT_AGENT_PREFIX);
         // Because the name is also used in Kubernetes, it should conform to domain name standard
         // No spaces, lower-cased

--- a/plugin/src/main/java/io/jenkins/plugins/remotingkafka/KafkaCloudSlave.java
+++ b/plugin/src/main/java/io/jenkins/plugins/remotingkafka/KafkaCloudSlave.java
@@ -1,6 +1,7 @@
 package io.jenkins.plugins.remotingkafka;
 
 import hudson.Extension;
+import hudson.Util;
 import hudson.model.Descriptor;
 import hudson.model.TaskListener;
 import hudson.slaves.*;
@@ -52,7 +53,7 @@ public class KafkaCloudSlave extends AbstractCloudSlave {
 
     public KafkaCloudSlave(KafkaKubernetesCloud cloud) throws Descriptor.FormException, IOException {
         super(getSlaveName(cloud.name),
-                cloud.getDescription(),
+                Util.fixNull(cloud.getDescription()),
                 cloud.getWorkingDir(),
                 KafkaKubernetesCloud.AGENT_NUM_EXECUTORS,
                 cloud.getNodeUsageMode(),

--- a/plugin/src/main/java/io/jenkins/plugins/remotingkafka/KafkaComputerLauncher.java
+++ b/plugin/src/main/java/io/jenkins/plugins/remotingkafka/KafkaComputerLauncher.java
@@ -149,6 +149,9 @@ public class KafkaComputerLauncher extends ComputerLauncher {
     private void launchKubernetesPod(KafkaCloudComputer computer) {
         try {
             KafkaCloudSlave slave = computer.getNode();
+            if (slave == null) {
+                throw new IllegalStateException("Node has been removed, cannot launch " + computer.getName());
+            }
             KubernetesClient client = slave.getCloud().connect();
 
             // Build Pod
@@ -293,7 +296,11 @@ public class KafkaComputerLauncher extends ComputerLauncher {
         String cloudJenkinsUrl = null;
         if (computer instanceof KafkaCloudComputer) {
             KafkaCloudSlave slave = (KafkaCloudSlave) computer.getNode();
-            cloudJenkinsUrl = slave.getCloud().getJenkinsUrl();
+            if (slave == null) {
+                LOGGER.warning("Cannot find node for computer " + computer.getName());
+            } else {
+                cloudJenkinsUrl = slave.getCloud().getJenkinsUrl();
+            }
         }
 
         String url = StringUtils.defaultIfBlank(cloudJenkinsUrl, locationConfiguration.getUrl());

--- a/plugin/src/main/java/io/jenkins/plugins/remotingkafka/KafkaComputerLauncher.java
+++ b/plugin/src/main/java/io/jenkins/plugins/remotingkafka/KafkaComputerLauncher.java
@@ -152,12 +152,13 @@ public class KafkaComputerLauncher extends ComputerLauncher {
     }
 
     private void launchKubernetesPod(KafkaCloudComputer computer) {
+        KubernetesClient client = null;
         try {
             KafkaCloudSlave slave = computer.getNode();
             if (slave == null) {
                 throw new IllegalStateException("Node has been removed, cannot launch " + computer.getName());
             }
-            KubernetesClient client = slave.getCloud().connect();
+            client = slave.getCloud().connect();
 
             // Build Pod
             Container agentContainer = new ContainerBuilder()
@@ -187,6 +188,10 @@ public class KafkaComputerLauncher extends ComputerLauncher {
             LOGGER.info(String.format("Created Pod: %s/%s", namespace, podId));
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, "Failed to launch Kubernetes pod for computer " + computer.getDisplayName(), e);
+        } finally {
+            if (client != null) {
+                client.close();
+            }
         }
     }
 

--- a/plugin/src/main/java/io/jenkins/plugins/remotingkafka/KafkaComputerLauncher.java
+++ b/plugin/src/main/java/io/jenkins/plugins/remotingkafka/KafkaComputerLauncher.java
@@ -40,7 +40,6 @@ import java.util.logging.Logger;
 public class KafkaComputerLauncher extends ComputerLauncher {
     private static final Logger LOGGER = Logger.getLogger(KafkaComputerLauncher.class.getName());
     private static final long DEFAULT_TIMEOUT = TimeUnit.SECONDS.toMillis(60);
-    private static final String K8S_AGENT_CONTAINER_NAME = "agent";
     private static final String K8S_AGENT_CONTAINER_IMAGE = "jenkins/remoting-kafka-agent:latest";
 
     @CheckForNull
@@ -162,7 +161,7 @@ public class KafkaComputerLauncher extends ComputerLauncher {
 
             // Build Pod
             Container agentContainer = new ContainerBuilder()
-                    .withName(K8S_AGENT_CONTAINER_NAME)
+                    .withName(slave.getName())
                     .withImage(K8S_AGENT_CONTAINER_IMAGE)
                     .withArgs(getLaunchArguments(computer).split(" "))
                     .build();

--- a/plugin/src/main/java/io/jenkins/plugins/remotingkafka/KafkaComputerLauncher.java
+++ b/plugin/src/main/java/io/jenkins/plugins/remotingkafka/KafkaComputerLauncher.java
@@ -39,7 +39,7 @@ import java.util.logging.Logger;
 
 public class KafkaComputerLauncher extends ComputerLauncher {
     private static final Logger LOGGER = Logger.getLogger(KafkaComputerLauncher.class.getName());
-    private static final long DEFAULT_TIMEOUT = 60000;
+    private static final long DEFAULT_TIMEOUT = TimeUnit.SECONDS.toMillis(60);
     private static final String K8S_AGENT_CONTAINER_NAME = "agent";
     private static final String K8S_AGENT_CONTAINER_IMAGE = "jenkins/remoting-kafka-agent:latest";
 
@@ -55,14 +55,20 @@ public class KafkaComputerLauncher extends ComputerLauncher {
     private boolean enableSSL;
 
     public KafkaComputerLauncher() {
+        this.enableSSL = false;
+    }
+
+    public KafkaComputerLauncher(String kafkaUsername, String sslTruststoreLocation, String sslKeystoreLocation) {
+        this.kafkaUsername = kafkaUsername;
+        this.sslTruststoreLocation = sslTruststoreLocation;
+        this.sslKeystoreLocation = sslKeystoreLocation;
+        this.enableSSL = true;
     }
 
     @DataBoundConstructor
     public KafkaComputerLauncher(String kafkaUsername, String sslTruststoreLocation, String sslKeystoreLocation,
                                  String enableSSL) {
-        this.kafkaUsername = kafkaUsername;
-        this.sslTruststoreLocation = sslTruststoreLocation;
-        this.sslKeystoreLocation = sslKeystoreLocation;
+        this(kafkaUsername, sslTruststoreLocation, sslKeystoreLocation);
         this.enableSSL = Boolean.valueOf(enableSSL);
     }
 

--- a/plugin/src/main/java/io/jenkins/plugins/remotingkafka/KafkaComputerLauncher.java
+++ b/plugin/src/main/java/io/jenkins/plugins/remotingkafka/KafkaComputerLauncher.java
@@ -40,7 +40,6 @@ import java.util.logging.Logger;
 public class KafkaComputerLauncher extends ComputerLauncher {
     private static final Logger LOGGER = Logger.getLogger(KafkaComputerLauncher.class.getName());
     private static final long DEFAULT_TIMEOUT = TimeUnit.SECONDS.toMillis(60);
-    private static final String K8S_AGENT_CONTAINER_IMAGE = "jenkins/remoting-kafka-agent:latest";
 
     @CheckForNull
     private transient volatile ExecutorService launcherExecutorService;
@@ -158,12 +157,13 @@ public class KafkaComputerLauncher extends ComputerLauncher {
             if (slave == null) {
                 throw new IllegalStateException("Node has been removed, cannot launch " + computer.getName());
             }
-            client = slave.getCloud().connect();
+            KafkaKubernetesCloud cloud = slave.getCloud();
+            client = cloud.connect();
 
             // Build Pod
             Container agentContainer = new ContainerBuilder()
                     .withName(slave.getName())
-                    .withImage(K8S_AGENT_CONTAINER_IMAGE)
+                    .withImage(cloud.getContainerImage())
                     .withArgs(getLaunchArguments(computer).split(" "))
                     .build();
 

--- a/plugin/src/main/java/io/jenkins/plugins/remotingkafka/KafkaKubernetesCloud.java
+++ b/plugin/src/main/java/io/jenkins/plugins/remotingkafka/KafkaKubernetesCloud.java
@@ -1,0 +1,122 @@
+package io.jenkins.plugins.remotingkafka;
+
+import hudson.Extension;
+import hudson.Util;
+import hudson.model.Computer;
+import hudson.model.Descriptor;
+import hudson.model.Label;
+import hudson.model.Node;
+import hudson.model.labels.LabelAtom;
+import hudson.slaves.Cloud;
+import hudson.slaves.NodeProvisioner.PlannedNode;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.apache.commons.lang.StringUtils;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import javax.annotation.CheckForNull;
+import java.util.*;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+public class KafkaKubernetesCloud extends Cloud {
+    private static final Logger LOGGER = Logger.getLogger(KafkaKubernetesCloud.class.getName());
+    private static final int AGENT_NUM_EXECUTORS = 1;
+
+    private String jenkinsUrl;
+    private String label;
+
+    @DataBoundConstructor
+    public KafkaKubernetesCloud(String name) {
+        super(name);
+    }
+
+    public String getJenkinsUrl() {
+        return jenkinsUrl;
+    }
+
+    @DataBoundSetter
+    public void setJenkinsUrl(String jenkinsUrl) {
+        this.jenkinsUrl = jenkinsUrl;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    @DataBoundSetter
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public Set<LabelAtom> getLabelSet() {
+        return Label.parse(label);
+    }
+
+    public String getNamespace() {
+        String ns = GlobalKafkaConfiguration.get().getKubernetesNamespace();
+        return StringUtils.isBlank(ns) ? "default" : ns;
+    }
+
+    public KubernetesClient connect() {
+        GlobalKafkaConfiguration globalConfig = GlobalKafkaConfiguration.get();
+        String serverUrl = globalConfig.getKubernetesUrl();
+        String namespace = getNamespace();
+        String serverCertificate = globalConfig.getKubernetesCertificate();
+        String credentialsId = globalConfig.getKubernetesCredentialsId();
+        boolean skipTlsVerify = globalConfig.getKubernetesSkipTlsVerify();
+
+        try (KubernetesClient client = new KubernetesFactoryAdapter(serverUrl, namespace,
+                Util.fixEmpty(serverCertificate), Util.fixEmpty(credentialsId), skipTlsVerify
+        ).createClient()) {
+            return client;
+        } catch (Exception e) {
+            LOGGER.warning("Error connecting to Kubernetes client from Cloud " + name);
+            return null;
+        }
+    }
+
+    @Override
+    public Collection<PlannedNode> provision(Label label, int excessWorkload) {
+        Set<String> allInProvisioning = getNodesInProvisioning(label);
+        LOGGER.info("In provisioning : " + allInProvisioning);
+        int toBeProvisioned = Math.max(0, excessWorkload - allInProvisioning.size());
+        LOGGER.info("Excess workload after pending Kubernetes agents: " + toBeProvisioned);
+
+        List<PlannedNode> provisionNodes = new ArrayList<>();
+        for (int i = 0; i < toBeProvisioned; i++) {
+            PlannedNode node = new PlannedNode(name,
+                    Computer.threadPoolForRemoting.submit(() -> new KafkaCloudSlave(this)),
+                    AGENT_NUM_EXECUTORS);
+            provisionNodes.add(node);
+        }
+        return provisionNodes;
+    }
+
+    public Set<String> getNodesInProvisioning(@CheckForNull Label label) {
+        if (label == null) return Collections.emptySet();
+        return label.getNodes().stream()
+            .filter(KafkaCloudSlave.class::isInstance)
+            .filter(node -> {
+                Computer computer = node.toComputer();
+                return computer != null && !computer.isOnline();
+            })
+            .map(Node::getNodeName)
+            .collect(Collectors.toSet());
+    }
+
+    @Override
+    public boolean canProvision(@CheckForNull Label label) {
+        if (label == null) return false;
+        return label.matches(getLabelSet());
+    }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<Cloud> {
+        @Override
+        public String getDisplayName() {
+            return "Kafka Kubernetes";
+        }
+    }
+
+}

--- a/plugin/src/main/java/io/jenkins/plugins/remotingkafka/KafkaKubernetesCloud.java
+++ b/plugin/src/main/java/io/jenkins/plugins/remotingkafka/KafkaKubernetesCloud.java
@@ -50,6 +50,7 @@ public class KafkaKubernetesCloud extends Cloud {
     private String namespace;
 
     private String jenkinsUrl;
+    private String containerImage;
     private String label;
     private Node.Mode nodeUsageMode;
     private String description;
@@ -118,6 +119,15 @@ public class KafkaKubernetesCloud extends Cloud {
     @DataBoundSetter
     public void setJenkinsUrl(String jenkinsUrl) {
         this.jenkinsUrl = jenkinsUrl;
+    }
+
+    public String getContainerImage() {
+        return containerImage;
+    }
+
+    @DataBoundSetter
+    public void setContainerImage(String containerImage) {
+        this.containerImage = containerImage;
     }
 
     public String getLabel() {

--- a/plugin/src/main/java/io/jenkins/plugins/remotingkafka/KafkaKubernetesCloud.java
+++ b/plugin/src/main/java/io/jenkins/plugins/remotingkafka/KafkaKubernetesCloud.java
@@ -70,6 +70,8 @@ public class KafkaKubernetesCloud extends Cloud {
                 Util.fixEmpty(serverCertificate), Util.fixEmpty(credentialsId), skipTlsVerify
         ).createClient()) {
             return client;
+        } catch (RuntimeException e) {
+            throw e;
         } catch (Exception e) {
             LOGGER.warning("Error connecting to Kubernetes client from Cloud " + name);
             return null;

--- a/plugin/src/main/java/io/jenkins/plugins/remotingkafka/KafkaKubernetesCloud.java
+++ b/plugin/src/main/java/io/jenkins/plugins/remotingkafka/KafkaKubernetesCloud.java
@@ -1,5 +1,12 @@
 package io.jenkins.plugins.remotingkafka;
 
+import com.cloudbees.plugins.credentials.CredentialsMatchers;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardCertificateCredentials;
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.Computer;
@@ -7,22 +14,40 @@ import hudson.model.Descriptor;
 import hudson.model.Label;
 import hudson.model.Node;
 import hudson.model.labels.LabelAtom;
+import hudson.security.ACL;
 import hudson.slaves.Cloud;
 import hudson.slaves.NodeProperty;
 import hudson.slaves.NodeProvisioner.PlannedNode;
+import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.kubernetes.credentials.TokenProducer;
+import org.jenkinsci.plugins.plaincredentials.FileCredentials;
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.interceptor.RequirePOST;
 
 import javax.annotation.CheckForNull;
 import java.util.*;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 public class KafkaKubernetesCloud extends Cloud {
     private static final Logger LOGGER = Logger.getLogger(KafkaKubernetesCloud.class.getName());
     public static final int AGENT_NUM_EXECUTORS = 1;
+
+    private String serverUrl;
+    @CheckForNull
+    private String serverCertificate;
+    private String credentialsId;
+    private boolean skipTlsVerify;
+    private String namespace;
 
     private String jenkinsUrl;
     private String label;
@@ -39,6 +64,51 @@ public class KafkaKubernetesCloud extends Cloud {
     @DataBoundConstructor
     public KafkaKubernetesCloud(String name) {
         super(name);
+    }
+
+    public String getServerUrl() {
+        return serverUrl;
+    }
+
+    @DataBoundSetter
+    public void setServerUrl(String serverUrl) {
+        this.serverUrl = serverUrl;
+    }
+
+    public String getServerCertificate() {
+        return serverCertificate;
+    }
+
+    @DataBoundSetter
+    public void setServerCertificate(String serverCertificate) {
+        this.serverCertificate = serverCertificate;
+    }
+
+    public String getCredentialsId() {
+        return credentialsId;
+    }
+
+    @DataBoundSetter
+    public void setCredentialsId(String credentialsId) {
+        this.credentialsId = credentialsId;
+    }
+
+    public boolean isSkipTlsVerify() {
+        return skipTlsVerify;
+    }
+
+    @DataBoundSetter
+    public void setSkipTlsVerify(boolean skipTlsVerify) {
+        this.skipTlsVerify = skipTlsVerify;
+    }
+
+    public String getNamespace() {
+        return StringUtils.defaultIfBlank(namespace, "default");
+    }
+
+    @DataBoundSetter
+    public void setNamespace(String namespace) {
+        this.namespace = namespace;
     }
 
     public String getJenkinsUrl() {
@@ -135,19 +205,7 @@ public class KafkaKubernetesCloud extends Cloud {
         return Label.parse(label);
     }
 
-    public String getNamespace() {
-        String ns = GlobalKafkaConfiguration.get().getKubernetesNamespace();
-        return StringUtils.isBlank(ns) ? "default" : ns;
-    }
-
     public KubernetesClient connect() {
-        GlobalKafkaConfiguration globalConfig = GlobalKafkaConfiguration.get();
-        String serverUrl = globalConfig.getKubernetesUrl();
-        String namespace = getNamespace();
-        String serverCertificate = globalConfig.getKubernetesCertificate();
-        String credentialsId = globalConfig.getKubernetesCredentialsId();
-        boolean skipTlsVerify = globalConfig.getKubernetesSkipTlsVerify();
-
         try (KubernetesClient client = new KubernetesFactoryAdapter(serverUrl, namespace,
                 Util.fixEmpty(serverCertificate), Util.fixEmpty(credentialsId), skipTlsVerify
         ).createClient()) {
@@ -180,13 +238,13 @@ public class KafkaKubernetesCloud extends Cloud {
     public Set<String> getNodesInProvisioning(@CheckForNull Label label) {
         if (label == null) return Collections.emptySet();
         return label.getNodes().stream()
-            .filter(KafkaCloudSlave.class::isInstance)
-            .filter(node -> {
-                Computer computer = node.toComputer();
-                return computer != null && !computer.isOnline();
-            })
-            .map(Node::getNodeName)
-            .collect(Collectors.toSet());
+                .filter(KafkaCloudSlave.class::isInstance)
+                .filter(node -> {
+                    Computer computer = node.toComputer();
+                    return computer != null && !computer.isOnline();
+                })
+                .map(Node::getNodeName)
+                .collect(Collectors.toSet());
     }
 
     @Override
@@ -200,6 +258,53 @@ public class KafkaKubernetesCloud extends Cloud {
         @Override
         public String getDisplayName() {
             return "Kafka Kubernetes";
+        }
+
+        @RequirePOST
+        public FormValidation doTestConnection(
+                @QueryParameter("serverUrl") String serverUrl,
+                @QueryParameter("credentialsId") String credentialsId,
+                @QueryParameter("serverCertificate") String serverCertificate,
+                @QueryParameter("skipTlsVerify") boolean skipTlsVerify,
+                @QueryParameter("namespace") String namespace
+        ) {
+            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+
+            try {
+                KubernetesClient client = new KubernetesFactoryAdapter(serverUrl, namespace,
+                        Util.fixEmpty(serverCertificate), Util.fixEmpty(credentialsId), skipTlsVerify
+                ).createClient();
+                // Call Pod list API to ensure functionality
+                client.pods().list();
+                return FormValidation.ok("Success");
+            } catch (KubernetesClientException e) {
+                LOGGER.log(Level.FINE, "Error testing Kubernetes connection", e);
+                return FormValidation.error("Error: %s", e.getCause() == null
+                        ? e.getMessage()
+                        : String.format("%s: %s", e.getCause().getClass().getName(), e.getCause().getMessage()));
+            } catch (Exception e) {
+                LOGGER.log(Level.FINE, "Error testing Kubernetes connection", e);
+                return FormValidation.error("Error: %s", e.getMessage());
+            }
+        }
+
+        @RequirePOST
+        public ListBoxModel doFillCredentialsIdItems(@QueryParameter String serverUrl) {
+            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+            return new StandardListBoxModel().withEmptySelection()
+                    .withMatching(
+                            CredentialsMatchers.anyOf(
+                                    CredentialsMatchers.instanceOf(StandardUsernamePasswordCredentials.class),
+                                    CredentialsMatchers.instanceOf(FileCredentials.class),
+                                    CredentialsMatchers.instanceOf(TokenProducer.class),
+                                    CredentialsMatchers.instanceOf(StandardCertificateCredentials.class),
+                                    CredentialsMatchers.instanceOf(StringCredentials.class)),
+                            CredentialsProvider.lookupCredentials(StandardCredentials.class,
+                                    Jenkins.get(),
+                                    ACL.SYSTEM,
+                                    serverUrl != null ? URIRequirementBuilder.fromUri(serverUrl).build()
+                                            : Collections.EMPTY_LIST
+                            ));
         }
     }
 

--- a/plugin/src/main/java/io/jenkins/plugins/remotingkafka/KafkaKubernetesCloud.java
+++ b/plugin/src/main/java/io/jenkins/plugins/remotingkafka/KafkaKubernetesCloud.java
@@ -8,6 +8,7 @@ import hudson.model.Label;
 import hudson.model.Node;
 import hudson.model.labels.LabelAtom;
 import hudson.slaves.Cloud;
+import hudson.slaves.NodeProperty;
 import hudson.slaves.NodeProvisioner.PlannedNode;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import org.apache.commons.lang.StringUtils;
@@ -21,10 +22,19 @@ import java.util.stream.Collectors;
 
 public class KafkaKubernetesCloud extends Cloud {
     private static final Logger LOGGER = Logger.getLogger(KafkaKubernetesCloud.class.getName());
-    private static final int AGENT_NUM_EXECUTORS = 1;
+    public static final int AGENT_NUM_EXECUTORS = 1;
 
     private String jenkinsUrl;
     private String label;
+    private Node.Mode nodeUsageMode;
+    private String description;
+    private String workingDir;
+    private List<? extends NodeProperty<?>> nodeProperties;
+
+    private String kafkaUsername;
+    private String sslTruststoreLocation;
+    private String sslKeystoreLocation;
+    private boolean enableSSL;
 
     @DataBoundConstructor
     public KafkaKubernetesCloud(String name) {
@@ -47,6 +57,78 @@ public class KafkaKubernetesCloud extends Cloud {
     @DataBoundSetter
     public void setLabel(String label) {
         this.label = label;
+    }
+
+    public Node.Mode getNodeUsageMode() {
+        return nodeUsageMode;
+    }
+
+    @DataBoundSetter
+    public void setNodeUsageMode(Node.Mode nodeUsageMode) {
+        this.nodeUsageMode = nodeUsageMode;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    @DataBoundSetter
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getWorkingDir() {
+        return workingDir;
+    }
+
+    @DataBoundSetter
+    public void setWorkingDir(String workingDir) {
+        this.workingDir = workingDir;
+    }
+
+    public List<? extends NodeProperty<?>> getNodeProperties() {
+        return nodeProperties;
+    }
+
+    @DataBoundSetter
+    public void setNodeProperties(List<? extends NodeProperty<?>> nodeProperties) {
+        this.nodeProperties = nodeProperties;
+    }
+
+    public String getKafkaUsername() {
+        return kafkaUsername;
+    }
+
+    @DataBoundSetter
+    public void setKafkaUsername(String kafkaUsername) {
+        this.kafkaUsername = kafkaUsername;
+    }
+
+    public String getSslTruststoreLocation() {
+        return sslTruststoreLocation;
+    }
+
+    @DataBoundSetter
+    public void setSslTruststoreLocation(String sslTruststoreLocation) {
+        this.sslTruststoreLocation = sslTruststoreLocation;
+    }
+
+    public String getSslKeystoreLocation() {
+        return sslKeystoreLocation;
+    }
+
+    @DataBoundSetter
+    public void setSslKeystoreLocation(String sslKeystoreLocation) {
+        this.sslKeystoreLocation = sslKeystoreLocation;
+    }
+
+    public boolean isEnableSSL() {
+        return enableSSL;
+    }
+
+    @DataBoundSetter
+    public void setEnableSSL(boolean enableSSL) {
+        this.enableSSL = enableSSL;
     }
 
     public Set<LabelAtom> getLabelSet() {

--- a/plugin/src/main/resources/io/jenkins/plugins/remotingkafka/KafkaComputerLauncher/main.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/remotingkafka/KafkaComputerLauncher/main.jelly
@@ -1,20 +1,13 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core"
->
+<j:jelly xmlns:j="jelly:core">
     <j:choose>
         <j:when test="${it.offline and !it.temporarilyOffline}">
             <j:if test="${h.hasPermission(it, it.CONNECT)}">
                 <p>
                     ${%Connect agent to Jenkins with Kafka:}
                 </p>
-                <j:if test="${it.launcher.enableSSL}">
-                    <pre>java${it.launcher.vmargs == null ? '' : ' ' + it.launcher.vmargs} -jar remoting-kafka-agent.jar -name ${it.name} -master ${h.inferHudsonURL(request)} -secret ${it.launcher.getLaunchSecret(it)} -kafkaURL ${it.launcher.kafkaURL} -kafkaUsername ${it.launcher.kafkaUsername} -sslTruststoreLocation ${it.launcher.sslTruststoreLocation} -sslKeystoreLocation ${it.launcher.sslKeystoreLocation}
-                    </pre>
-                </j:if>
-                <j:if test="${!it.launcher.enableSSL}">
-                    <pre>java${it.launcher.vmargs == null ? '' : ' ' + it.launcher.vmargs} -jar remoting-kafka-agent.jar -name ${it.name} -master ${h.inferHudsonURL(request)} -secret ${it.launcher.getLaunchSecret(it)} -kafkaURL ${it.launcher.kafkaURL} -noauth
-                    </pre>
-                </j:if>
+                <pre>java${it.launcher.vmargs == null ? '' : ' ' + it.launcher.vmargs} -jar remoting-kafka-agent.jar ${it.launcher.getLaunchArguments(it)}
+                </pre>
             </j:if>
         </j:when>
         <j:otherwise>

--- a/plugin/src/main/resources/io/jenkins/plugins/remotingkafka/KafkaKubernetesCloud/config.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/remotingkafka/KafkaKubernetesCloud/config.jelly
@@ -30,6 +30,10 @@
         <f:textbox/>
     </f:entry>
 
+    <f:entry title="${%Container image}" field="containerImage">
+        <f:textbox default="jenkins/remoting-kafka-agent:latest"/>
+    </f:entry>
+
     <f:entry title="${%Node Description}" field="description">
         <f:textbox/>
     </f:entry>

--- a/plugin/src/main/resources/io/jenkins/plugins/remotingkafka/KafkaKubernetesCloud/config.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/remotingkafka/KafkaKubernetesCloud/config.jelly
@@ -6,12 +6,38 @@
         <f:textbox default="kafka-kubernetes" clazz="required"/>
     </f:entry>
 
+    <f:entry title="${%Description}" field="description">
+        <f:textbox/>
+    </f:entry>
+
+    <f:entry title="${%Working directory}" field="workingDir">
+        <f:textbox default="/home/jenkins"/>
+    </f:entry>
+
     <f:entry title="${%Labels}" field="label">
         <f:textbox/>
+    </f:entry>
+
+    <f:entry title="${%Usage}" field="nodeUsageMode"  help="/help/system-config/master-slave/usage.html">
+        <f:enum>${it.description}</f:enum>
     </f:entry>
 
     <f:entry title="${%Jenkins URL}" field="jenkinsUrl">
         <f:textbox/>
     </f:entry>
+
+    <f:optionalBlock inline="true" name="enableSSL" title="Enable SSL" field="enableSSL">
+        <f:entry title="${%Kafka username}" field="kafkaUsername">
+            <f:textbox/>
+        </f:entry>
+        <f:entry title="${%SSL Truststore Location}" field="sslTruststoreLocation">
+            <f:textbox/>
+        </f:entry>
+        <f:entry title="${%SSL Keystore Location}" field="sslKeystoreLocation">
+            <f:textbox/>
+        </f:entry>
+    </f:optionalBlock>
+
+    <f:descriptorList title="${%Node Properties}" descriptors="${h.getNodePropertyDescriptors(descriptor.clazz)}" field="nodeProperties" />
 
 </j:jelly>

--- a/plugin/src/main/resources/io/jenkins/plugins/remotingkafka/KafkaKubernetesCloud/config.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/remotingkafka/KafkaKubernetesCloud/config.jelly
@@ -1,29 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
-         xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
 
     <f:entry title="${%Name}" field="name">
         <f:textbox default="kafka-kubernetes" clazz="required"/>
     </f:entry>
 
-    <f:entry title="${%Description}" field="description">
+    <f:entry title="${%Kubernetes URL}" field="serverUrl">
         <f:textbox/>
     </f:entry>
-
-    <f:entry title="${%Working directory}" field="workingDir">
-        <f:textbox default="/home/jenkins"/>
+    <f:entry title="${%Kubernetes server certificate key}" field="serverCertificate">
+        <f:textarea/>
     </f:entry>
-
-    <f:entry title="${%Labels}" field="label">
-        <f:textbox/>
+    <f:entry title="${%Disable https certificate check}" field="skipTlsVerify">
+        <f:checkbox />
     </f:entry>
-
-    <f:entry title="${%Usage}" field="nodeUsageMode"  help="/help/system-config/master-slave/usage.html">
-        <f:enum>${it.description}</f:enum>
+    <f:entry title="${%Kubernetes Namespace}" field="namespace">
+        <f:textbox default="default"/>
     </f:entry>
+    <f:entry title="${%Credentials}" field="credentialsId">
+        <c:select/>
+    </f:entry>
+    <f:validateButton
+            title="${%Test Connection}" progress="${%Testing...}"
+            method="testConnection"
+            with="serverUrl,credentialsId,serverCertificate,skipTlsVerify,namespace" />
 
     <f:entry title="${%Jenkins URL}" field="jenkinsUrl">
         <f:textbox/>
+    </f:entry>
+
+    <f:entry title="${%Node Description}" field="description">
+        <f:textbox/>
+    </f:entry>
+    <f:entry title="${%Working Directory}" field="workingDir">
+        <f:textbox default="/home/jenkins"/>
+    </f:entry>
+    <f:entry title="${%Labels}" field="label">
+        <f:textbox/>
+    </f:entry>
+    <f:entry title="${%Usage}" field="nodeUsageMode"  help="/help/system-config/master-slave/usage.html">
+        <f:enum>${it.description}</f:enum>
     </f:entry>
 
     <f:optionalBlock inline="true" name="enableSSL" title="Enable SSL" field="enableSSL">

--- a/plugin/src/main/resources/io/jenkins/plugins/remotingkafka/KafkaKubernetesCloud/config.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/remotingkafka/KafkaKubernetesCloud/config.jelly
@@ -1,0 +1,17 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
+
+    <f:entry title="${%Name}" field="name">
+        <f:textbox default="kafka-kubernetes" clazz="required"/>
+    </f:entry>
+
+    <f:entry title="${%Labels}" field="label">
+        <f:textbox/>
+    </f:entry>
+
+    <f:entry title="${%Jenkins URL}" field="jenkinsUrl">
+        <f:textbox/>
+    </f:entry>
+
+</j:jelly>

--- a/plugin/src/test/java/io/jenkins/plugins/remotingkafka/GlobalKafkaConfigurationTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/remotingkafka/GlobalKafkaConfigurationTest.java
@@ -18,6 +18,13 @@ public class GlobalKafkaConfigurationTest {
         g.setSslKeyCredentialsId("dummy");
         g.setSslKeystoreCredentialsId("dummy");
         g.setSslTruststoreCredentialsId("dummy");
+        g.setUseKubernetes(true);
+        g.setKubernetesIp("192.168.99.100");
+        g.setKubernetesApiPort("8443");
+        g.setKubernetesCertificate("dummy");
+        g.setKafkaCredentialsId("dummy");
+        g.setKubernetesSkipTlsVerify(false);
+        g.setKubernetesNamespace("default");
         g.save();
         g.load();
     }

--- a/plugin/src/test/java/io/jenkins/plugins/remotingkafka/KafkaCloudSlaveTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/remotingkafka/KafkaCloudSlaveTest.java
@@ -1,0 +1,28 @@
+package io.jenkins.plugins.remotingkafka;
+
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.*;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class KafkaCloudSlaveTest {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void testGetSlaveNameIsRandom() {
+        final String baseName = "base-name";
+        final String name1 = KafkaCloudSlave.getSlaveName(baseName);
+        final String name2 = KafkaCloudSlave.getSlaveName(baseName);
+        assertThat(name1, is(not(name2)));
+    }
+
+    @Test
+    public void testGetSlaveNameContainBaseName() {
+        final String baseName = "base-name";
+        final String name = KafkaCloudSlave.getSlaveName(baseName);
+        assertThat(name, containsString(baseName));
+    }
+
+}

--- a/plugin/src/test/java/io/jenkins/plugins/remotingkafka/KafkaKubernetesCloudTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/remotingkafka/KafkaKubernetesCloudTest.java
@@ -1,0 +1,41 @@
+package io.jenkins.plugins.remotingkafka;
+
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.*;
+
+import hudson.model.labels.LabelAtom;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class KafkaKubernetesCloudTest {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void testCanProvisionSingleLabel() {
+        KafkaKubernetesCloud cloud = new KafkaKubernetesCloud("kafka-kubernetes");
+        cloud.setLabel("test");
+        assertThat(cloud.canProvision(null), is(false));
+        assertThat(cloud.canProvision(new LabelAtom("test")), is(true));
+        assertThat(cloud.canProvision(new LabelAtom("wrong")), is(false));
+    }
+
+    @Test
+    public void testCanProvisionMultipleLabels() {
+        KafkaKubernetesCloud cloud = new KafkaKubernetesCloud("kafka-kubernetes");
+        cloud.setLabel("label1 label2");
+        assertThat(cloud.canProvision(new LabelAtom("label1")), is(true));
+        assertThat(cloud.canProvision(new LabelAtom("label3")), is(false));
+    }
+
+    @Test
+    public void testGetNamespaceDefaultValue() {
+        KafkaKubernetesCloud cloud = new KafkaKubernetesCloud("kafka-kubernetes");
+        cloud.setNamespace(null);
+        assertThat(cloud.getNamespace(), is("default"));
+        cloud.setNamespace("");
+        assertThat(cloud.getNamespace(), is("default"));
+    }
+
+}


### PR DESCRIPTION
Improvements:

- [x] Additional config field for agent (remote FS, node usage mode,....)
- [x] ~Retention strategy, now agent always stay after running job~ (move to phase 3)
- [x] Tests

Bugs:

- [x] Job always fail on **first** run on newly-created agent, the subsequence runs are ok though. The error comes from agent side: 

```
Started by user unknown or anonymous
Building remotely on kafka-kubernetes-t3v3q (cloud) in workspace /workingDir/workspace/test-cloud
[test-cloud] $ /bin/sh -xe /tmp/jenkins6468229840531327921.sh
+ echo hi
hi
FATAL: Remote call on kafka-kubernetes-t3v3q failed
Also:   hudson.remoting.Channel$CallSiteStackTrace: Remote call to kafka-kubernetes-t3v3q
		at hudson.remoting.Channel.attachCallSiteStackTrace(Channel.java:1741)
		at hudson.remoting.Request.call(Request.java:202)
		at hudson.remoting.RemoteInvocationHandler.invoke(RemoteInvocationHandler.java:286)
		at com.sun.proxy.$Proxy5.fetch(Unknown Source)
		at hudson.remoting.RemoteClassLoader.findClass(RemoteClassLoader.java:315)
		at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
		at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
		at hudson.util.ProcessTree.get(ProcessTree.java:412)
		at hudson.Launcher$RemoteLauncher$KillTask.call(Launcher.java:1097)
		at hudson.Launcher$RemoteLauncher$KillTask.call(Launcher.java:1088)
		at hudson.remoting.UserRequest.perform(UserRequest.java:212)
		at hudson.remoting.UserRequest.perform(UserRequest.java:54)
		at hudson.remoting.Request$2.run(Request.java:369)
		at hudson.remoting.InterceptingExecutorService$1.call(InterceptingExecutorService.java:72)
		at java.util.concurrent.FutureTask.run(FutureTask.java:266)
		at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
		at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
		at io.jenkins.plugins.remotingkafka.Engine$1.lambda$newThread$0(Engine.java:47)
java.lang.ClassNotFoundException: javax.servlet.ServletException
	at hudson.remoting.RemoteClassLoader$ClassLoaderProxy.fetch(RemoteClassLoader.java:808)
	at sun.reflect.GeneratedMethodAccessor124.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at hudson.remoting.RemoteInvocationHandler$RPCRequest.perform(RemoteInvocationHandler.java:929)
	at hudson.remoting.Request$2.run(Request.java:369)
	at hudson.remoting.InterceptingExecutorService$1.call(InterceptingExecutorService.java:72)
	at org.jenkinsci.remoting.CallableDecorator.call(CallableDecorator.java:19)
	at hudson.remoting.CallableDecoratorList$1.call(CallableDecoratorList.java:21)
	at jenkins.util.ContextResettingExecutorService$2.call(ContextResettingExecutorService.java:46)
	at jenkins.security.ImpersonatingExecutorService$2.call(ImpersonatingExecutorService.java:71)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
Also:   hudson.remoting.Channel$CallSiteStackTrace: Remote call to kafka-kubernetes-t3v3q
		at hudson.remoting.Channel.attachCallSiteStackTrace(Channel.java:1743)
		at hudson.remoting.UserRequest$ExceptionResponse.retrieve(UserRequest.java:357)
		at hudson.remoting.Channel.call(Channel.java:957)
		at hudson.Launcher$RemoteLauncher.kill(Launcher.java:1085)
		at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:510)
		at hudson.model.Run.execute(Run.java:1816)
		at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
		at hudson.model.ResourceController.execute(ResourceController.java:97)
		at hudson.model.Executor.run(Executor.java:429)
Caused: java.lang.NoClassDefFoundError: javax/servlet/ServletException
	at hudson.util.ProcessTree.get(ProcessTree.java:412)
	at hudson.Launcher$RemoteLauncher$KillTask.call(Launcher.java:1097)
	at hudson.Launcher$RemoteLauncher$KillTask.call(Launcher.java:1088)
	at hudson.remoting.UserRequest.perform(UserRequest.java:212)
	at hudson.remoting.UserRequest.perform(UserRequest.java:54)
	at hudson.remoting.Request$2.run(Request.java:369)
	at hudson.remoting.InterceptingExecutorService$1.call(InterceptingExecutorService.java:72)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at io.jenkins.plugins.remotingkafka.Engine$1.lambda$newThread$0(Engine.java:47)
	at java.lang.Thread.run(Thread.java:748)
Caused: java.io.IOException: Remote call on kafka-kubernetes-t3v3q failed
	at hudson.remoting.Channel.call(Channel.java:963)
	at hudson.Launcher$RemoteLauncher.kill(Launcher.java:1085)
	at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:510)
	at hudson.model.Run.execute(Run.java:1816)
	at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
	at hudson.model.ResourceController.execute(ResourceController.java:97)
	at hudson.model.Executor.run(Executor.java:429)
Finished: FAILURE
```