### PR TITLE
Remove unnecessary usages of "slave" term.

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/remotingkafka/KafkaCloudComputer.java
+++ b/plugin/src/main/java/io/jenkins/plugins/remotingkafka/KafkaCloudComputer.java
@@ -5,10 +5,9 @@ import hudson.slaves.AbstractCloudComputer;
 import java.util.logging.Logger;
 
 public class KafkaCloudComputer extends AbstractCloudComputer<KafkaCloudSlave> {
-    private static final Logger LOGGER = Logger.getLogger(KafkaCloudComputer.class.getName());
 
-    public KafkaCloudComputer(KafkaCloudSlave slave) {
-        super(slave);
+    public KafkaCloudComputer(KafkaCloudSlave agent) {
+        super(agent);
     }
 
 }

--- a/plugin/src/main/resources/io/jenkins/plugins/remotingkafka/Messages.properties
+++ b/plugin/src/main/resources/io/jenkins/plugins/remotingkafka/Messages.properties
@@ -7,4 +7,4 @@ KafkaComputerLauncher.NonnullExecutorService=Launcher Executor Service should be
 GlobalKafkaConfiguration.KafkaConnectionURLWarning=Please specify a Kafka connection URL
 GlobalKafkaConfiguration.KafkaSecurityWarning=Required for Kafka security reasons
 GlobalKafkaConfiguration.ZookeeperURLWarning=Please specify a Zookeeper URL
-KafkaComputerLauncher.UnexpectedError=Unexpected error in launching a slave. This is probably a bug in Jenkins.
+KafkaComputerLauncher.UnexpectedError=Unexpected error in launching an agent. This is probably a bug in Jenkins.

--- a/plugin/src/test/java/io/jenkins/plugins/remotingkafka/KafkaCloudSlaveTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/remotingkafka/KafkaCloudSlaveTest.java
@@ -16,7 +16,7 @@ public class KafkaCloudSlaveTest {
     public JenkinsRule j = new JenkinsRule();
 
     @Test
-    public void testSlaveInitWithCloudOfNullArguments() throws Descriptor.FormException, IOException {
+    public void testAgentInitWithCloudOfNullArguments() throws Descriptor.FormException, IOException {
         final KafkaKubernetesCloud cloud = new KafkaKubernetesCloud("kafka-kubernetes");
         cloud.setDescription(null);
         cloud.setWorkingDir(null);
@@ -28,7 +28,7 @@ public class KafkaCloudSlaveTest {
     }
 
     @Test
-    public void testGetSlaveNameBlankBaseName() {
+    public void testGetAgentNameBlankBaseName() {
         String baseName = null;
         String name = KafkaCloudSlave.getSlaveName(baseName);
         assertTrue(StringUtils.isNotBlank(name));
@@ -38,7 +38,7 @@ public class KafkaCloudSlaveTest {
     }
 
     @Test
-    public void testGetSlaveNameIsRandom() {
+    public void testGetAgentNameIsRandom() {
         final String baseName = "base-name";
         final String name1 = KafkaCloudSlave.getSlaveName(baseName);
         final String name2 = KafkaCloudSlave.getSlaveName(baseName);
@@ -46,7 +46,7 @@ public class KafkaCloudSlaveTest {
     }
 
     @Test
-    public void testGetSlaveNameContainBaseName() {
+    public void testGetAgentNameContainBaseName() {
         final String baseName = "base-name";
         final String name = KafkaCloudSlave.getSlaveName(baseName);
         assertThat(name, containsString(baseName));

--- a/plugin/src/test/java/io/jenkins/plugins/remotingkafka/KafkaComputerLauncherTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/remotingkafka/KafkaComputerLauncherTest.java
@@ -30,8 +30,8 @@ public class KafkaComputerLauncherTest {
         g.load();
         KafkaComputerLauncher launcher = new KafkaComputerLauncher("", "",
                 "", "false");
-        DumbSlave slave = new DumbSlave("test", "/tmp/", launcher);
-        j.jenkins.addNode(slave);
+        DumbSlave agent = new DumbSlave("test", "/tmp/", launcher);
+        j.jenkins.addNode(agent);
         Computer c = j.jenkins.getComputer("test");
         assertNotNull(c);
         Thread.sleep(10000); // wait to connect master to kafka.
@@ -45,7 +45,7 @@ public class KafkaComputerLauncherTest {
             t.start();
             Thread.sleep(10000); // wait to connect agent to jenkins master.
             FreeStyleProject p = j.createFreeStyleProject();
-            p.setAssignedNode(slave);
+            p.setAssignedNode(agent);
             j.buildAndAssertSuccess(p);
         } finally {
             t.interrupt();

--- a/plugin/src/test/java/io/jenkins/plugins/remotingkafka/KafkaKubernetesCloudTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/remotingkafka/KafkaKubernetesCloudTest.java
@@ -37,14 +37,14 @@ public class KafkaKubernetesCloudTest {
 
         Collection<NodeProvisioner.PlannedNode> provisionedNodes = cloud.provision(new LabelAtom("test"), 1);
         assertThat(provisionedNodes, hasSize(1));
-        KafkaCloudSlave slave = (KafkaCloudSlave) provisionedNodes.iterator().next().future.get();
+        KafkaCloudSlave agent = (KafkaCloudSlave) provisionedNodes.iterator().next().future.get();
         TaskListener listener = new LogTaskListener(Logger.getLogger(KafkaKubernetesCloudTest.class.getName()), Level.INFO);
-        PodResource<Pod, DoneablePod> pod = k.getClient().pods().inNamespace(cloud.getNamespace()).withName(slave.getNodeName());
+        PodResource<Pod, DoneablePod> pod = k.getClient().pods().inNamespace(cloud.getNamespace()).withName(agent.getNodeName());
 
         assertNull(pod.get());
 
         // Poll for pod creation
-        j.jenkins.addNode(slave);
+        j.jenkins.addNode(agent);
         final int TIMEOUT = 30;
         for(int i = 0; i < TIMEOUT; i++) {
             if (pod.get() != null) break;
@@ -52,7 +52,7 @@ public class KafkaKubernetesCloudTest {
         }
         assertNotNull(pod.get());
 
-        slave._terminate(listener);
+        agent._terminate(listener);
         assertNull(pod.get());
     }
 


### PR DESCRIPTION
I was going through `remoting` to remove as many instances of the "slave" term as I could. I glanced in this project and noticed a few here so I decided to submit them. The one in `Messages` is probably the only important one since it's user facing. I decided to add the other internal ones because it's better to limit the propagation of the term.

I couldn't get all the tests to pass on my development system even without any changes. ci.jenkins-ci.org is currently down so I can't check results there.